### PR TITLE
Fix typo in property comment

### DIFF
--- a/src/Cake.ESLint/ESLintSettings.cs
+++ b/src/Cake.ESLint/ESLintSettings.cs
@@ -196,7 +196,7 @@ namespace Cake.ESLint
 
         /// <summary>
         /// Gets or sets a value indicating whether
-        /// to check only hanged files.
+        /// to check only changed files.
         /// <para>Option: <c>--cache</c>.</para>
         /// </summary>
         public bool Cache { get; set; }


### PR DESCRIPTION
Fixes a typo in the property comment of [ESLintSettings.Cache](https://cakebuild.net/api/Cake.ESLint/ESLintSettings/7E35E03E)