### PR TITLE
(GH-80) re-enabled snupkg creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,19 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Fetch all tags and branches
         run: git fetch --prune --unshallow
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # unittests needs 3.1
+          dotnet-version: '3.1.x'
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # gitversion needs 5.0
+          dotnet-version: '5.0.x'
+      - uses: actions/setup-dotnet@v1.8.2
+        with:
+          # need .NET 6 rc2 to build
+          dotnet-version: '6.0.x'
+          include-prerelease: true
       - name: Cache Tools
         uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,19 @@ jobs:
       uses: actions/checkout@v2.3.4
     - name: Fetch all tags and branches
       run: git fetch --prune --unshallow
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # unittests needs 3.1
+        dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # gitversion needs 5.0
+        dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1.8.2
+      with:
+        # need .NET 6 rc2 to build
+        dotnet-version: '6.0.x'
+        include-prerelease: true
     - name: Cache Tools
       uses: actions/cache@v2.1.6
       with:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "allowPrerelease": true,
+        "version": "6.0.100-rc.2",
+        "rollForward": "latestFeature"
+    }
+}

--- a/src/Cake.ESLint/Cake.ESLint.csproj
+++ b/src/Cake.ESLint/Cake.ESLint.csproj
@@ -3,10 +3,7 @@
         <TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
-        <!-- Don't publish snupkg for now, until NET 6 is released.
-            see https://github.com/NuGet/Home/issues/10791
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        -->
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This, however, requires at least .NET 6 rc2 (`6.0.100-rc.2`) to build.

fixes #80 