### PR TITLE
Add additional log messages for tool resolution

### DIFF
--- a/src/Cake.ESLint/ESLintRunner.cs
+++ b/src/Cake.ESLint/ESLintRunner.cs
@@ -279,6 +279,7 @@ namespace Cake.ESLint
             // instead of any other version.
             if (settings.NoWorkingDirectory || settings.WorkingDirectory == null)
             {
+                log.Verbose($"No working directory set.");
                 return;
             }
 
@@ -286,6 +287,7 @@ namespace Cake.ESLint
                 fileSystem.GetDirectory(settings.WorkingDirectory.Combine("node_modules/.bin"));
             if (!nodeBin.Exists)
             {
+                log.Warning($"node_modules/.bin does not exist in {settings.WorkingDirectory.FullPath}.");
                 return;
             }
 


### PR DESCRIPTION
Adds additional log message in case no working directory is set or if no `node_modules/.bin` folder does exist in defined working directory.

Fixes #282